### PR TITLE
add: 유저의  post list, post like list 조회 로직(service,repository) 추가/ 상태유지정보

### DIFF
--- a/src/community/community.repository.ts
+++ b/src/community/community.repository.ts
@@ -78,6 +78,14 @@ export class CommunityRepository {
     return result;
   }
 
+  async getPostsOfUser(userId: number): Promise<Post[]> {
+    return this.postRepository
+      .createQueryBuilder()
+      .select(['id'])
+      .where('user_id = :userId', { userId: userId })
+      .getRawMany();
+  }
+
   async createOrDeletePostLike(postId, userId) {
     const ifLiked = await this.postLikeRepository.findOne({
       where: { postId: postId, userId: userId },
@@ -97,5 +105,13 @@ export class CommunityRepository {
     } else if (ifLiked) {
       return await this.postLikeRepository.delete({ id: ifLiked.id });
     }
+  }
+
+  async getPostLikesOfUser(userId: number): Promise<Post[]> {
+    return this.postLikeRepository
+      .createQueryBuilder()
+      .select(['post_id'])
+      .where('user_id = :userId', { userId: userId })
+      .getRawMany();
   }
 }

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -45,6 +45,16 @@ export class CommunityService {
     return await this.CommunityRepository.getPostList(subCategoryId);
   }
 
+  async getPostsOfUser(userId: number): Promise<number[]> {
+    const data = await this.CommunityRepository.getPostsOfUser(userId);
+    return data.map((item) => Object.values(item)[0]);
+  }
+
+  async getPostLikesOfUser(userId: number): Promise<number[]> {
+    const data = await this.CommunityRepository.getPostLikesOfUser(userId);
+    return data.map((item) => Object.values(item)[0]);
+  }
+
   async createOrDeletePostLike(data, userId) {
     const { postId } = data;
     return await this.CommunityRepository.createOrDeletePostLike(


### PR DESCRIPTION
[구현한 기능]
- 유저가 작성한 커뮤니티 게시물의 id 배열 조회
- 유저가 추천한 게시물의 id 배열 조회

[상세설명]
토큰 검증 후 req.user에 담을 정보들이어서 컨트롤러단은 따로 라우터를 설정 안해두었고 서비스와 레포지토리에만 코드를 추가해두었습니다.