### PR TITLE
add: community comment 관련 api

### DIFF
--- a/src/community/community.module.ts
+++ b/src/community/community.module.ts
@@ -1,3 +1,4 @@
+import { JwtModule, JwtService } from '@nestjs/jwt';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommunityController } from './community.controller';
@@ -12,6 +13,12 @@ import { Comment } from 'src/entities/Comment';
 import { RankerProfile } from 'src/entities/RankerProfile';
 import { Ranking } from 'src/entities/Ranking';
 import { Tier } from 'src/entities/Tier';
+import { CommentLike } from 'src/entities/CommentLike';
+import { AuthModule } from 'src/auth/auth.module';
+import { UserModule } from 'src/user/user.module';
+import { jwtConstants } from 'src/auth/constants';
+import { AuthService } from 'src/auth/auth.service';
+import { JwtStrategy } from 'src/auth/jwt.strategy';
 
 @Module({
   imports: [
@@ -22,12 +29,25 @@ import { Tier } from 'src/entities/Tier';
       User,
       PostLike,
       Comment,
+      CommentLike,
       RankerProfile,
       Ranking,
       Tier,
     ]),
+    AuthModule,
+    UserModule,
+    JwtModule.register({
+      secret: jwtConstants.secret,
+      signOptions: { expiresIn: jwtConstants.expiresIn },
+    }),
   ],
   controllers: [CommunityController],
-  providers: [CommunityService, CommunityRepository],
+  providers: [
+    CommunityService,
+    CommunityRepository,
+    AuthService,
+    JwtService,
+    JwtStrategy,
+  ],
 })
 export class CommunityModule {}

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -2,6 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { CommunityRepository } from './community.repository';
 import { CreatePostDto } from './dto/createPost.dto';
 import { uploadToS3 } from 'src/utiles/aws';
+import {
+  CreateCommentDto,
+  CreateCommentLikesDto,
+  DeleteCommentDto,
+  UpdateCommentDto,
+} from './dto/comment.dto';
 
 @Injectable()
 export class CommunityService {
@@ -61,5 +67,39 @@ export class CommunityService {
       postId,
       userId,
     );
+  }
+
+  async createComment(commentData: CreateCommentDto) {
+    await this.CommunityRepository.createComment(commentData);
+  }
+
+  async deleteComment(creteria: DeleteCommentDto) {
+    await this.CommunityRepository.deleteComment(creteria);
+  }
+  async updateComment(creteria: DeleteCommentDto, toUpdateContent: string) {
+    await this.CommunityRepository.updateComment(creteria, toUpdateContent);
+  }
+
+  async readComments(postId: number) {
+    return await this.CommunityRepository.readComments(postId);
+  }
+
+  async createCommentLikes(creteria: CreateCommentLikesDto) {
+    await this.CommunityRepository.createCommentLikes(creteria);
+  }
+
+  async getCommentsOfUser(userId: number) {
+    const data = await this.CommunityRepository.getIdsOfCommentCreatedByUser(
+      userId,
+    );
+    return data.map((item) => Object.values(item)[0]);
+  }
+
+  async getCommentsLikesOfUser(userId: number): Promise<number[]> {
+    const data =
+      await this.CommunityRepository.getIsOfLikesAboutCommentsCreatedByUser(
+        userId,
+      );
+    return data.map((item) => Object.values(item)[0]);
   }
 }

--- a/src/community/dto/comment.dto.ts
+++ b/src/community/dto/comment.dto.ts
@@ -1,0 +1,41 @@
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class CreateCommentDto {
+  @IsString()
+  @IsNotEmpty()
+  readonly content: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  readonly groupOrder: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  readonly userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  readonly postId: number;
+}
+
+export class DeleteCommentDto {
+  @IsNumber()
+  @IsNotEmpty()
+  readonly userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  readonly id: number;
+}
+
+export class UpdateCommentDto extends DeleteCommentDto {}
+
+export class CreateCommentLikesDto {
+  @IsNumber()
+  @IsNotEmpty()
+  readonly userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  readonly commentId: number;
+}


### PR DESCRIPTION
[구현한 기능]
- 댓글/대댓글 생성
- 댓글/대댓글 수정
- 댓글/대댓글 삭제
- 댓글/대댓글 조회
- 댓글 좋아요 생성/삭제
- 유저가 작성한 댓글의 id 목록 조회
- 유저가 추천한 댓글의 id 목록 조회

[상세설명]
Guard 적용하여 기능 작성하였으니 참고하시면 될 것 같습니다.

