### PR TITLE
add: mypage 조회 / 수정 기능 구현

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,3 +1,6 @@
+import { CommunityRepository } from './../community/community.repository';
+import { MainCategory } from 'src/entities/MainCategory';
+import { SubCategory } from 'src/entities/SubCategory';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
@@ -13,10 +16,31 @@ import { jwtConstants } from './constants';
 import { JwtStrategy } from './jwt.strategy';
 import { PassportModule } from '@nestjs/passport';
 import { AuthRepository } from './auth.repository';
+import { RankModule } from 'src/rank/rank.module';
+import { Post } from 'src/entities/Post';
+import { PostLike } from 'src/entities/PostLike';
+import { CommentLike } from 'src/entities/CommentLike';
+import { RankerProfile } from 'src/entities/RankerProfile';
+import { Ranking } from 'src/entities/Ranking';
+import { Tier } from 'src/entities/Tier';
+import { Comment } from 'src/entities/Comment';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Field, Career]),
+    TypeOrmModule.forFeature([
+      User,
+      Field,
+      Career,
+      SubCategory,
+      MainCategory,
+      Post,
+      PostLike,
+      Comment,
+      CommentLike,
+      RankerProfile,
+      Ranking,
+      Tier,
+    ]),
     HttpModule,
     UserModule,
     PassportModule,
@@ -24,9 +48,16 @@ import { AuthRepository } from './auth.repository';
       secret: jwtConstants.secret,
       signOptions: { expiresIn: jwtConstants.expiresIn },
     }),
+    RankModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, UserService, JwtStrategy, AuthRepository],
+  providers: [
+    AuthService,
+    UserService,
+    JwtStrategy,
+    AuthRepository,
+    CommunityRepository,
+  ],
   exports: [AuthService, AuthRepository],
 })
 export class AuthModule {}

--- a/src/community/community.module.ts
+++ b/src/community/community.module.ts
@@ -49,5 +49,6 @@ import { JwtStrategy } from 'src/auth/jwt.strategy';
     JwtService,
     JwtStrategy,
   ],
+  exports: [CommunityRepository, CommunityService],
 })
 export class CommunityModule {}

--- a/src/community/community.repository.ts
+++ b/src/community/community.repository.ts
@@ -90,10 +90,16 @@ export class CommunityRepository {
     return result;
   }
 
-  async getIdsOfPostsCreatedByUser(userId: number): Promise<Post[]> {
+  async getPostsCreatedByUser(userId: number): Promise<Post[]> {
     return this.postRepository
       .createQueryBuilder()
-      .select(['id'])
+      .select([
+        'id',
+        'title',
+        'content_url as contentUrl',
+        'sub_category_id as subCategoryId',
+        'created_at as createdAt',
+      ])
       .where('user_id = :userId', { userId: userId })
       .getRawMany();
   }
@@ -119,7 +125,7 @@ export class CommunityRepository {
     }
   }
 
-  async getIdsOfLikesAboutPostCreatedByUser(userId: number): Promise<Post[]> {
+  async getLikesAboutPostCreatedByUser(userId: number): Promise<Post[]> {
     return this.postLikeRepository
       .createQueryBuilder()
       .select(['post_id'])
@@ -157,7 +163,7 @@ export class CommunityRepository {
     await this.commentLikeRepository.delete(creteria);
   }
 
-  async getIdsOfCommentCreatedByUser(userId: number): Promise<Comment[]> {
+  async getCommentCreatedByUser(userId: number): Promise<Comment[]> {
     return this.commentRepository
       .createQueryBuilder()
       .select(['id'])
@@ -165,7 +171,7 @@ export class CommunityRepository {
       .getRawMany();
   }
 
-  async getIsOfLikesAboutCommentsCreatedByUser(
+  async getLikesAboutCommentsCreatedByUser(
     userId: number,
   ): Promise<CommentLike[]> {
     return this.commentLikeRepository

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -52,17 +52,14 @@ export class CommunityService {
   }
 
   async getIdsOfPostsCreatedByUser(userId: number): Promise<number[]> {
-    const data = await this.CommunityRepository.getIdsOfPostsCreatedByUser(
-      userId,
-    );
+    const data = await this.CommunityRepository.getPostsCreatedByUser(userId);
     return data.map((item) => Object.values(item)[0]);
   }
 
   async getIdsOfLikesAboutPostCreatedByUser(userId: number): Promise<number[]> {
-    const data =
-      await this.CommunityRepository.getIdsOfLikesAboutPostCreatedByUser(
-        userId,
-      );
+    const data = await this.CommunityRepository.getLikesAboutPostCreatedByUser(
+      userId,
+    );
     return data.map((item) => Object.values(item)[0]);
   }
 
@@ -93,18 +90,16 @@ export class CommunityService {
     await this.CommunityRepository.createCommentLikes(creteria);
   }
 
-  async getCommentsOfUser(userId: number) {
-    const data = await this.CommunityRepository.getIdsOfCommentCreatedByUser(
-      userId,
-    );
+  async getIdsOfCommentCreatedByUser(userId: number) {
+    const data = await this.CommunityRepository.getCommentCreatedByUser(userId);
     return data.map((item) => Object.values(item)[0]);
   }
 
-  async getCommentsLikesOfUser(userId: number): Promise<number[]> {
+  async getIsOfLikesAboutCommentsCreatedByUser(
+    userId: number,
+  ): Promise<number[]> {
     const data =
-      await this.CommunityRepository.getIsOfLikesAboutCommentsCreatedByUser(
-        userId,
-      );
+      await this.CommunityRepository.getLikesAboutCommentsCreatedByUser(userId);
     return data.map((item) => Object.values(item)[0]);
   }
 }

--- a/src/rank/rank.module.ts
+++ b/src/rank/rank.module.ts
@@ -38,5 +38,6 @@ import { Career } from 'src/entities/Career';
     RankingRepository,
     TierRepository,
   ],
+  exports: [RankerProfileRepository],
 })
 export class RankModule {}

--- a/src/rank/rank_profile.repository.ts
+++ b/src/rank/rank_profile.repository.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { RankerProfile } from '../entities/RankerProfile';
 import { Ranking } from '../entities/Ranking';
 import { Tier } from '../entities/Tier';
+import { RankService } from './rank.service';
 
 @Injectable()
 export class RankerProfileRepository {
@@ -144,5 +145,26 @@ export class RankerProfileRepository {
       .getRawMany();
 
     return ranker;
+  }
+
+  async getMyPage(userId: number) {
+    //todo 추후에 auth 로직에서 해당 유저의 ranker profile 정보가 없을 경우 현상님의 로직을 사용해서 회원 가입 시 애초애 정보를 등록하는 과정으로 리펙토링 하겠습니다.
+
+    let result;
+    const ranker = await this.rankerProfileRepository.findBy({
+      userId: userId,
+    })[0];
+    if (!ranker) {
+      result = {
+        userName: '랭킹 정보를 검색해주세요!',
+        profileText: '랭킹 정보를 검색해주세요!',
+        profileImageUrl: '랭킹 정보를 검색해주세요!',
+        email: '랭킹 정보를 검색해주세요!',
+      };
+    } else {
+      result = ranker;
+    }
+    console.log('ranker: ', result);
+    return result;
   }
 }

--- a/src/user/dto/mypage.dto.ts
+++ b/src/user/dto/mypage.dto.ts
@@ -1,0 +1,37 @@
+import { IsDate, IsNumber, IsString } from 'class-validator';
+
+class PostDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  contentUrl: string;
+
+  @IsNumber()
+  subCategoryId: number;
+
+  @IsDate()
+  createdAt: Date;
+}
+
+export class myPageDto {
+  @IsString()
+  readonly userName: string;
+
+  @IsString()
+  readonly email: string;
+
+  @IsString()
+  readonly profileText: string;
+
+  @IsString()
+  readonly profileImageUrl: string;
+
+  @IsNumber()
+  readonly fieldId: number;
+
+  @IsNumber()
+  readonly careerId: number;
+
+  readonly posts: PostDto[];
+}

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,0 +1,23 @@
+import { AuthGuard } from '@nestjs/passport';
+import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common';
+import { UserService } from './user.service';
+
+@Controller('user')
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  @Get()
+  @UseGuards(AuthGuard('jwt'))
+  async getMyPage(@Req() req) {
+    return await this.userService.getMyPage(req.user.id);
+  }
+
+  @Patch()
+  @UseGuards(AuthGuard('jwt'))
+  async updateMyPage(@Body() body, @Req() req) {
+    const userId = req.user.id;
+    const { fieldId, careerId } = body;
+    await this.userService.updateMyPage(userId, fieldId, careerId);
+    return { message: 'USER_INFO_UPDATED' };
+  }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,3 +1,6 @@
+import { CommunityRepository } from './../community/community.repository';
+import { Post } from './../entities/Post';
+import { RankerProfile } from 'src/entities/RankerProfile';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../entities/User';
 import { Field } from '../entities/Field';
@@ -6,10 +9,38 @@ import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserRepository } from './user.repository';
+import { UserController } from './user.controller';
+import { CommunityModule } from './../community/community.module';
+import { RankerProfileRepository } from 'src/rank/rank_profile.repository';
+import { RankModule } from 'src/rank/rank.module';
+import { SubCategory } from 'src/entities/SubCategory';
+import { PostLike } from 'src/entities/PostLike';
+import { Comment } from 'src/entities/Comment';
+import { CommentLike } from 'src/entities/CommentLike';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Field, Career]), HttpModule],
-  providers: [UserService, UserRepository],
+  imports: [
+    TypeOrmModule.forFeature([
+      User,
+      Field,
+      Career,
+      RankerProfile,
+      Post,
+      SubCategory,
+      PostLike,
+      Comment,
+      CommentLike,
+    ]),
+    HttpModule,
+    RankModule,
+  ],
+  providers: [
+    UserService,
+    UserRepository,
+    RankerProfileRepository,
+    CommunityRepository,
+  ],
   exports: [UserService, UserRepository],
+  controllers: [UserController],
 })
 export class UserModule {}

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -17,7 +17,7 @@ export class UserRepository {
     });
   }
 
-  async getById(id: number): Promise<User> {
+  async getByUserId(id: number): Promise<User> {
     return await this.userRepository.findOneBy({
       id,
     });
@@ -25,5 +25,15 @@ export class UserRepository {
   async createUser(signUpData: SignUpDto) {
     const user = await this.userRepository.create(signUpData);
     await this.userRepository.save(user);
+  }
+
+  async updateMyPage(userId: number, fieldId: number, careerId: number) {
+    await this.userRepository.update(
+      { id: userId },
+      {
+        fieldId: fieldId,
+        careerId: careerId,
+      },
+    );
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,3 +1,4 @@
+import { RankerProfileRepository } from './../rank/rank_profile.repository';
 import { SignUpDto } from './../auth/dto/auth.dto';
 import { Injectable } from '@nestjs/common';
 import { User } from 'src/entities/User';
@@ -5,6 +6,8 @@ import { UserRepository } from './user.repository';
 import { lastValueFrom, map } from 'rxjs';
 import * as dotenv from 'dotenv';
 import { HttpService } from '@nestjs/axios';
+import { CommunityRepository } from 'src/community/community.repository';
+import { myPageDto } from './dto/mypage.dto';
 dotenv.config();
 
 @Injectable()
@@ -12,6 +15,8 @@ export class UserService {
   constructor(
     private readonly http: HttpService,
     private readonly userRepository: UserRepository,
+    private readonly rankerProfileRepository: RankerProfileRepository,
+    private readonly communityRepository: CommunityRepository,
   ) {}
   // todo refactoring : getUser 메서드 getUserByKeyword로 통합
   async getByGithubId(githubId: number): Promise<User> {
@@ -19,7 +24,7 @@ export class UserService {
   }
 
   async getById(id: number): Promise<User> {
-    return await this.userRepository.getById(id);
+    return await this.userRepository.getByUserId(id);
   }
 
   async getGithubAccessToken(code: string): Promise<unknown> {
@@ -55,5 +60,30 @@ export class UserService {
 
   async createUser(signUpData: SignUpDto) {
     await this.userRepository.createUser(signUpData);
+  }
+
+  async getMyPage(userId: number) {
+    // 유저네임, 프로필 텍스트, 이메일, 프로필 이미지 -> RankerProfile
+    const { userName, profileText, profileImageUrl, email } =
+      await this.rankerProfileRepository.getMyPage(userId);
+    // 개발분야, 경력 -> User
+    const { careerId, fieldId } = await this.userRepository.getByUserId(userId);
+    // 작성한 글 목록(제목, 카테고리, 날짜, id) -> Post
+    const posts = await this.communityRepository.getPostsCreatedByUser(userId);
+
+    const result: myPageDto = {
+      userName,
+      profileText,
+      profileImageUrl,
+      email,
+      careerId,
+      fieldId,
+      posts,
+    };
+    return result;
+  }
+
+  async updateMyPage(userId: number, fieldId: number, careerId: number) {
+    await this.userRepository.updateMyPage(userId, fieldId, careerId);
   }
 }


### PR DESCRIPTION
[구현한 기능]
- mypage 조회
- mypage 정보 수정

[상세설명]
- mypage 조회
mypage에서 가져와야 하는 정보 중, rankerprofile 테이블에 있는 정보가 있어요. 이때, 만약 어떤 유저가 우리 서비스에 회원가입은 했으나 자신의 랭킹정보를 검색하지 않았다면, rankerprofile 테이블에서는 그 유저의 정보를 찾을 수 없습니다. 없는 정보를 요청하면 db에서는 에러를 반환하구요.
이때 제가 할 수 있는 대처는
1. 가져올 정보가 db에 없을 경우 null을 반환한다.
2. 현상님이 작성한 getRankerDetail() 서비스 함수를 실행하여 유저의 랭킹 정보를 db에 넣은 후 넣은 데이터를 다시 가져온다.

두가지 입니다.

첫번째 방법으로 하면 user 엔티티에 username은 추가 할 필요가 없지만, 유저 입장에서는 자신의 정보가 나타나지 않음이 어색하고,
두번째 방법으로 하면, 현상님은 getRankerDetail함수의 인자를 userName으로 만드셨기 때문에 user 엔티티에 username 컬럼이 추가되어, 회원가입 시 userName도 등록되게 하는 것입니다. 

일단 1번으로 진행

[추후 리펙토링 사항]
- mypage 조회의 경우 추후에 auth 로직에서 해당 유저의 ranker profile 정보가 없을 경우 현상님의 코드를 재사용해서 회원 가입 시 애초애 정보를 등록하는 과정으로 리펙토링 하겠습니다.



