### PR TITLE
add : 토큰 검증 후 반환할 상태유지정보 추가

### DIFF
--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,3 +1,4 @@
+import { CommunityService } from './../community/community.service';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
@@ -5,7 +6,7 @@ import { jwtConstants } from './constants';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(private readonly communityService: CommunityService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: true,
@@ -14,10 +15,30 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    const user = { id: payload.userId };
     // todo 상태유지가 필요한 정보 추가 필요, but, 로직이 구현이 안되어있으므로 로직 만든 후 추가예정
     // 상태유지 필요 정보 : commentLike, postLike, comment, post
-    //
+    const userId = payload.userId;
+    const idsOfPostsCreatedByUser =
+      await this.communityService.getIdsOfPostsCreatedByUser(userId);
+
+    const idsOfLikesAboutPostCreatedByUser =
+      await this.communityService.getIdsOfLikesAboutPostCreatedByUser(userId);
+
+    const idsOfCommentsCreatedByUser =
+      await this.communityService.getIdsOfCommentCreatedByUser(userId);
+
+    const idsOfLikesAboutCommentCreatedByUser =
+      await this.communityService.getIsOfLikesAboutCommentsCreatedByUser(
+        userId,
+      );
+
+    const user = {
+      id: userId,
+      idsOfPostsCreatedByUser,
+      idsOfLikesAboutPostCreatedByUser,
+      idsOfCommentsCreatedByUser,
+      idsOfLikesAboutCommentCreatedByUser,
+    };
     return user;
   }
 }

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -78,7 +78,7 @@ export class CommunityService {
   async deleteComment(creteria: DeleteCommentDto) {
     await this.CommunityRepository.deleteComment(creteria);
   }
-  async updateComment(creteria: DeleteCommentDto, toUpdateContent: string) {
+  async updateComment(creteria: UpdateCommentDto, toUpdateContent: string) {
     await this.CommunityRepository.updateComment(creteria, toUpdateContent);
   }
 


### PR DESCRIPTION
[구현한 기능]
- 토큰 검증 후 반환할 정보(상태유지 정보) 추가

[상세설명]
- id: userId
- idsOfPostsCreatedByUser : 유저가 생성한 post의 id 배열
- idsOfLikesAboutPostCreatedByUser : 유저가 추천한 post like의 id 배열 
- idsOfCommentsCreatedByUser : 유저가 생성한 댓글의 id 배열
- idsOfLikesAboutCommentCreatedByUser : 유저가 추천한 댓글 like의 id 배열