### PR TITLE
refactor : global error/exception filter

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,8 @@ import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 
 import * as ormConfig from '../config/ormConfig';
+import { APP_FILTER } from '@nestjs/core';
+import { AllExceptionsFilter } from './utiles/http-exception.filter';
 
 @Module({
   imports: [
@@ -20,6 +22,12 @@ import * as ormConfig from '../config/ormConfig';
     UserModule,
   ],
   controllers: [],
-  providers: [],
+  providers: [
+    {
+      // 의존성 주입이 가능하도록 module에도 설정해준다.
+      provide: APP_FILTER,
+      useClass: AllExceptionsFilter,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,13 @@
 import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { AllExceptionsFilter } from './utiles/http-exception.filter';
 
 import * as morgan from 'morgan';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -13,6 +15,9 @@ async function bootstrap() {
       transform: true,
     }),
   );
+
+  app.useGlobalFilters(new AllExceptionsFilter());
+
   app.use(morgan('dev'));
   app.enableCors();
 

--- a/src/utiles/http-exception.filter.ts
+++ b/src/utiles/http-exception.filter.ts
@@ -1,0 +1,43 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import { QueryFailedError } from 'typeorm';
+
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message = (exception as any).message.message;
+    let code = 'HttpException';
+
+    switch (exception.constructor) {
+      case HttpException: // for HttpException
+        status = (exception as HttpException).getStatus();
+        break;
+
+      case QueryFailedError: // for TypeOrm error
+        status = HttpStatus.UNPROCESSABLE_ENTITY;
+        message = (exception as QueryFailedError).message;
+        code = (exception as any).code;
+        break;
+
+      default: // default
+        status = HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    response.status(status).json({
+      statusCode: status,
+      message: (exception as any).message,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}


### PR DESCRIPTION
[구현한 기능]
- [ ] 엄밀한 타입 정의 
- [v] 예외 및 에러 처리 : 글로벌 예외 및 에러 필터 구현
- [ ] 올바른 상태코드 사용
- [ ] 사용하지 않는 패키지 삭제

[상세설명]
- utiles 디렉토리에 http-exception.filter.ts 파일에 구현하였습니다.
- HttpException / TypeOrm error를 구분하여 상태코드와 에러메시지를 반환하도록 구현하였으며 그 외 잡히지 않는 에러는 default로 500번 에러를 반환하도록 했습니다.
- 아마, switch...case 문에 등록하지 않은 에러는 500으로 잡힐테니 예외처리 해야 할 것이 있다면 에러 유형에 따라 등록하여 사용하면 될 것 같습니다.