### PR TITLE
refactor : auth, mypage

### DIFF
--- a/config/ormConfig.ts
+++ b/config/ormConfig.ts
@@ -21,7 +21,7 @@ const config: TypeOrmModuleOptions = {
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE,
-  synchronize: false,
+  synchronize: true,
   logging: false,
   entities: [
     Career,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,6 @@
 import { AuthService } from './auth.service';
 import { Controller, Post, Body, Get } from '@nestjs/common';
-import { GithubCodeDto, SignUpDto } from './dto/auth.dto';
+import { GithubCodeDto, SignUpWithUserNameDto } from './dto/auth.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -12,7 +12,7 @@ export class AuthController {
   }
 
   @Post('/sign-up')
-  signUp(@Body() userData: SignUpDto) {
+  signUp(@Body() userData: SignUpWithUserNameDto) {
     return this.authService.signUp(userData);
   }
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -25,6 +25,11 @@ import { Ranking } from 'src/entities/Ranking';
 import { Tier } from 'src/entities/Tier';
 import { Comment } from 'src/entities/Comment';
 import { CommunityService } from 'src/community/community.service';
+import { RankService } from 'src/rank/rank.service';
+import { RankingRepository } from 'src/rank/ranking.repository';
+import { TierRepository } from 'src/rank/tier.repository';
+import { UserRepository } from 'src/user/user.repository';
+import { RankerProfileRepository } from 'src/rank/rankerProfile.repository';
 
 @Module({
   imports: [
@@ -50,6 +55,7 @@ import { CommunityService } from 'src/community/community.service';
       signOptions: { expiresIn: jwtConstants.expiresIn },
     }),
     RankModule,
+    RankerProfile,
   ],
   controllers: [AuthController],
   providers: [
@@ -59,6 +65,11 @@ import { CommunityService } from 'src/community/community.service';
     AuthRepository,
     CommunityRepository,
     CommunityService,
+    RankService,
+    RankingRepository,
+    TierRepository,
+    UserRepository,
+    RankerProfileRepository,
   ],
   exports: [AuthService, AuthRepository],
 })

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -26,6 +26,12 @@ export class SignUpDto {
   readonly isKorean: boolean;
 }
 
+export class SignUpWithUserNameDto extends SignUpDto {
+  @Type(() => String)
+  @IsString()
+  readonly userName: string;
+}
+
 export class AuthorizedUser {
   readonly id: number;
   readonly idsOfPostsCreatedByUser?: Post[];

--- a/src/community/community.module.ts
+++ b/src/community/community.module.ts
@@ -19,6 +19,11 @@ import { UserModule } from 'src/user/user.module';
 import { jwtConstants } from 'src/auth/constants';
 import { AuthService } from 'src/auth/auth.service';
 import { JwtStrategy } from 'src/auth/jwt.strategy';
+import { RankerProfileRepository } from 'src/rank/rankerProfile.repository';
+import { RankService } from 'src/rank/rank.service';
+import { RankModule } from 'src/rank/rank.module';
+import { RankingRepository } from 'src/rank/ranking.repository';
+import { TierRepository } from 'src/rank/tier.repository';
 
 @Module({
   imports: [
@@ -36,6 +41,7 @@ import { JwtStrategy } from 'src/auth/jwt.strategy';
     ]),
     AuthModule,
     UserModule,
+    RankModule,
     JwtModule.register({
       secret: jwtConstants.secret,
       signOptions: { expiresIn: jwtConstants.expiresIn },
@@ -48,6 +54,10 @@ import { JwtStrategy } from 'src/auth/jwt.strategy';
     AuthService,
     JwtService,
     JwtStrategy,
+    RankService,
+    RankerProfileRepository,
+    RankingRepository,
+    TierRepository,
   ],
   exports: [CommunityRepository, CommunityService],
 })

--- a/src/entities/Comment.ts
+++ b/src/entities/Comment.ts
@@ -38,7 +38,7 @@ export class Comment {
   updatedAt: Date | null;
 
   @ManyToOne(() => User, (user) => user.comments, {
-    onDelete: 'NO ACTION',
+    onDelete: 'CASCADE',
     onUpdate: 'NO ACTION',
   })
   @JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])

--- a/src/entities/CommentLike.ts
+++ b/src/entities/CommentLike.ts
@@ -37,7 +37,7 @@ export class CommentLike {
   comment: Comment;
 
   @ManyToOne(() => User, (user) => user.commentLikes, {
-    onDelete: 'NO ACTION',
+    onDelete: 'CASCADE',
     onUpdate: 'NO ACTION',
   })
   @JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])

--- a/src/entities/Post.ts
+++ b/src/entities/Post.ts
@@ -49,7 +49,7 @@ export class Post {
   comments: Comment[];
 
   @ManyToOne(() => User, (user) => user.posts, {
-    onDelete: 'NO ACTION',
+    onDelete: 'CASCADE',
     onUpdate: 'NO ACTION',
   })
   @JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])

--- a/src/entities/PostLike.ts
+++ b/src/entities/PostLike.ts
@@ -30,14 +30,14 @@ export class PostLike {
   updatedAt: Date | null;
 
   @ManyToOne(() => Post, (post) => post.postLikes, {
-    onDelete: 'NO ACTION',
+    onDelete: 'CASCADE',
     onUpdate: 'NO ACTION',
   })
   @JoinColumn([{ name: 'post_id', referencedColumnName: 'id' }])
   post: Post;
 
   @ManyToOne(() => User, (user) => user.postLikes, {
-    onDelete: 'NO ACTION',
+    onDelete: 'CASCADE',
     onUpdate: 'NO ACTION',
   })
   @JoinColumn([{ name: 'user_id', referencedColumnName: 'id' }])

--- a/src/entities/RankerProfile.ts
+++ b/src/entities/RankerProfile.ts
@@ -34,8 +34,8 @@ export class RankerProfile {
   @Column('varchar', { name: 'homepage_url', nullable: true, length: 2083 })
   homepageUrl: string | null;
 
-  @Column('varchar', { name: 'email', length: 255 })
-  email: string;
+  @Column('varchar', { name: 'email', nullable: true, length: 255 })
+  email: string | null;
 
   @Column('varchar', { name: 'company', nullable: true, length: 255 })
   company: string | null;

--- a/src/rank/rank.service.ts
+++ b/src/rank/rank.service.ts
@@ -42,6 +42,7 @@ export class RankService {
         },
       },
     );
+    console.log('data: ', data);
 
     await this.rankerProfileRepository.createRankerProfile(data);
 

--- a/src/rank/rankerProfile.repository.ts
+++ b/src/rank/rankerProfile.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { identity } from 'rxjs';
 import { Repository } from 'typeorm';
 import { RankerProfile } from '../entities/RankerProfile';
 import { Ranking } from '../entities/Ranking';
@@ -159,7 +160,7 @@ export class RankerProfileRepository {
     let result;
     const ranker = await this.rankerProfileRepository.findBy({
       userId: userId,
-    })[0];
+    });
     if (!ranker) {
       result = {
         userName: '랭킹 정보를 검색해주세요!',
@@ -172,5 +173,22 @@ export class RankerProfileRepository {
     }
 
     return result;
+  }
+
+  async updateRankerProfile(
+    userName,
+    profileImageUrl,
+    homepageUrl,
+    email,
+    company,
+    region,
+    userId,
+  ) {
+    return await this.rankerProfileRepository
+      .createQueryBuilder()
+      .update(RankerProfile)
+      .set({ profileImageUrl, homepageUrl, email, company, region, userId })
+      .where('name = :name', { name: userName })
+      .execute();
   }
 }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -12,10 +12,17 @@ export class UserRepository {
     private readonly userRepository: Repository<User>,
   ) {}
 
-  async getByGithubId(githubId: number): Promise<User> {
+  async getByGithubId(githubId: number) {
     return await this.userRepository.findOneBy({
       githubId,
     });
+  }
+
+  async getUserIdByGithubId(githubId: number) {
+    const user = await this.userRepository.findOneBy({
+      githubId,
+    });
+    return user.id;
   }
 
   async getByUserId(id: number): Promise<User> {
@@ -23,6 +30,7 @@ export class UserRepository {
       id,
     });
   }
+
   async createUser(signUpData: SignUpDto) {
     const user = await this.userRepository.create(signUpData);
     await this.userRepository.save(user);

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,3 +1,4 @@
+import { RankerProfile } from 'src/entities/RankerProfile';
 import { RankerProfileRepository } from './../rank/rankerProfile.repository';
 import { SignUpDto } from './../auth/dto/auth.dto';
 import { Injectable } from '@nestjs/common';
@@ -71,16 +72,17 @@ export class UserService {
 
   async getMyPage(userId: number) {
     // 유저네임, 프로필 텍스트, 이메일, 프로필 이미지 -> RankerProfile
-    const { userName, profileText, profileImageUrl, email } =
-      await this.rankerProfileRepository.getMyPage(userId);
+    const [user] = await this.rankerProfileRepository.getMyPage(userId);
+    const { name, profileText, profileImageUrl, email } = user;
     // 개발분야, 경력 -> User
+
     const { careerId, fieldId, isKorean } =
       await this.userRepository.getByUserId(userId);
     // 작성한 글 목록(제목, 카테고리, 날짜, id) -> Post
     const posts = await this.communityRepository.getPostsCreatedByUser(userId);
 
     const result: MyPageDto = {
-      userName,
+      userName: name,
       profileText,
       profileImageUrl,
       email,


### PR DESCRIPTION
회원가입 과정에서 랭커 정보가 없는 경우 랭커정보를 자동으로 조회하도록 로직을 추가하고 랭커정보 갱신 시 랭커프로파일 테이블의 user_id 컬럼은 추가되지 않으므로 회원 가입 후 생성된 user_id를 update 쿼리를 활용하여 삽입해줌. userid를 추가해줘야 랭커 프로필 테이블에서 정보를 가져올 수 있기 때문