### PR TITLE
refactor : Add isLikedByUser

### DIFF
--- a/config/ormConfig.ts
+++ b/config/ormConfig.ts
@@ -21,8 +21,8 @@ const config: TypeOrmModuleOptions = {
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE,
-  synchronize: false,
-  logging: true,
+  synchronize: true,
+  logging: false,
   entities: [
     Career,
     Comment,

--- a/src/community/community.controller.ts
+++ b/src/community/community.controller.ts
@@ -234,8 +234,8 @@ export class CommunityController {
   @UseGuards(OptionalAuthGuard)
   @Get('/posts/:post_id/comments')
   async getComments(@Req() req, @Param('post_id') postId: number) {
-    const userId: number = req.user.id;
-    return await this.communityService.readComments(userId, postId);
+    const user = req.user;
+    return await this.communityService.readComments(user, postId);
   }
   // 댓글좋아요 생성/삭제
   @UseGuards(AuthGuard('jwt'))

--- a/src/community/community.repository.ts
+++ b/src/community/community.repository.ts
@@ -307,7 +307,7 @@ export class CommunityRepository {
     return await this.commentRepository.exist({ where: { id: commentId } });
   }
 
-  async readComments(postId: number) {
+  async readComments(postId: number, depth: number) {
     return await this.commentRepository
       .createQueryBuilder()
       .select([
@@ -340,128 +340,14 @@ export class CommunityRepository {
         'ranking.ranker_profile_id = ranker_profile.id',
       )
       .leftJoin('tier', 'tier', 'ranking.tier_id = tier.id')
-      .where('comment.post_id = :postId AND comment.depth = 1', {
+      .where('comment.post_id = :postId AND comment.depth = :depth', {
         postId: postId,
+        depth: depth,
       })
       .orderBy('comment.group_order', 'ASC')
       .addOrderBy('comment.created_at', 'ASC')
       .getRawMany();
   }
-
-  async readReComments(postId: number) {
-    return await this.commentRepository
-      .createQueryBuilder()
-      .select([
-        'comment.user_id as userId',
-        'comment.group_order as groupOrder',
-        'comment.id as reCommentId',
-        'ranker_profile.name as userName',
-        'ranker_profile.profile_image_url as profileImageUrl',
-        'comment.content as content',
-        'tier.name as tier',
-        'comment.depth as depth',
-        `DATE_FORMAT(comment.created_at, '%Y-%m-%d %H:%i:%s') as createdAt`,
-        `DATE_FORMAT(comment.updated_at, '%Y-%m-%d %H:%i:%s') as updatedAt`,
-      ])
-      .addSelect((subQuery) => {
-        return subQuery
-          .select('COUNT(comment_like.id)', 'likeNumber')
-          .from(CommentLike, 'comment_like')
-          .where('comment.id = comment_like.comment_id');
-      }, 'likeNumber')
-      .leftJoin('user', 'user', 'comment.user_id = user.id')
-      .leftJoin(
-        'ranker_profile',
-        'ranker_profile',
-        'user.id = ranker_profile.user_id',
-      )
-      .leftJoin(
-        'ranking',
-        'ranking',
-        'ranking.ranker_profile_id = ranker_profile.id',
-      )
-      .leftJoin('tier', 'tier', 'ranking.tier_id = tier.id')
-      .where('comment.post_id = :postId AND comment.depth = 2', {
-        postId: postId,
-      })
-      .orderBy('comment.group_order', 'ASC')
-      .addOrderBy('comment.created_at', 'ASC')
-      .getRawMany();
-  }
-
-  // async readComments(postId: number) {
-  //   // userName, profileImg -> rankerRepository
-  //   // id, groupOrder, createdAt, updatedAt, content -> commentRepository
-  //   // tier -> tearRepository
-  //   // commentLikeNumber -> commentLikeRepository
-
-  //   const comments = await this.commentRepository
-  //     .createQueryBuilder()
-  //     .select([
-  //       'comment.user_id as userId',
-  //       'comment.group_order as groupOrder',
-  //       'comment.id as commentId',
-  //       'ranker_profile.name as userName',
-  //       'ranker_profile.profile_image_url as profileImageUrl',
-  //       'comment.content as content',
-  //       'tier.name as tier',
-  //       'comment.depth as depth',
-  //       `DATE_FORMAT(comment.created_at, '%Y-%m-%d %H:%i:%s') as createdAt`,
-  //       `DATE_FORMAT(comment.updated_at, '%Y-%m-%d %H:%i:%s') as updatedAt`,
-  //     ])
-  //     .addSelect((subQuery) => {
-  //       return subQuery
-  //         .select('COUNT(comment_like.id)', 'likeNumber')
-  //         .from(CommentLike, 'comment_like')
-  //         .where('comment.id = comment_like.comment_id');
-  //     }, 'likeNumber')
-  //     // .addSelect(
-  //     //   `(SELECT JSON_ARRAYAGG(JSON_OBJECT(
-  //     //     'groupOrder', comment.group_order,
-  //     //     'commentId',comment.id,
-  //     //     'userName',ranker_profile.name,
-  //     //     'profileImageUrl', ranker_profile.profile_image_url,
-  //     //   'content', comment.content,
-  //     //   'tier', tier.name,
-  //     //   'createdAt', DATE_FORMAT(comment.created_at, '%Y-%m-%d %H:%i:%s'),
-  //     //   'updatedAt', DATE_FORMAT(comment.updated_at, '%Y-%m-%d %H:%i:%s')
-  //     //     )) from comment where comment.group_order = groupOrder) as reComment`,
-  //     // )
-  //     .leftJoin('user', 'user', 'comment.user_id = user.id')
-  //     .leftJoin(
-  //       'ranker_profile',
-  //       'ranker_profile',
-  //       'user.id = ranker_profile.user_id',
-  //     )
-  //     .leftJoin(
-  //       'ranking',
-  //       'ranking',
-  //       'ranking.ranker_profile_id = ranker_profile.id',
-  //     )
-  //     .leftJoin('tier', 'tier', 'ranking.tier_id = tier.id')
-  //     .where('comment.post_id = :postId', { postId: postId })
-  //     .orderBy('comment.group_order', 'ASC')
-  //     .addOrderBy('comment.created_at', 'ASC')
-  //     // .groupBy('comment.group_order')
-  //     // .addGroupBy('comment.id')
-  //     // .addGroupBy('user.id')
-  //     // .addGroupBy('ranker_profile.profile_image_url')
-  //     // .addGroupBy('comment.content')
-  //     // .addGroupBy('tier.name')
-  //     // .addGroupBy('comment.created_at')
-  //     // .addGroupBy('comment.updated_at')
-  //     .getRawMany();
-
-  //   return comments;
-  //   // comments.map((comment, i) => {
-  //   //   comment[i].groupOrder;
-  //   // });
-
-  //   // return await this.commentRepository.find({
-  //   //   where: { postId: postId },
-  //   //   order: { groupOrder: 'asc', createdAt: 'asc' },
-  //   // });
-  // }
 
   async createCommentLikes(criteria: CreateCommentLikesDto) {
     const isExist = await this.commentLikeRepository.exist({

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -179,15 +179,41 @@ export class CommunityService {
     );
   }
 
-  async readComments(userId: number, postId: number) {
-    const comments = await this.CommunityRepository.readComments(postId);
-    const reComments = await this.CommunityRepository.readReComments(postId);
+  async readComments(user, postId: number) {
+    enum depth {
+      COMMENT = 1,
+      RE_COMMENT = 2,
+    }
 
-    comments.map((item) => {
-      item.isCreatedByUser = item.userId === userId ? true : false;
+    const comments = await this.CommunityRepository.readComments(
+      postId,
+      depth.COMMENT,
+    );
+    const reComments = await this.CommunityRepository.readComments(
+      postId,
+      depth.RE_COMMENT,
+    );
+
+    comments.map((comment) => {
+      comment.isCreatedByUser =
+        user.idsOfCommentsCreatedByUser.indexOf(comment.commentId) >= 0
+          ? true
+          : false;
+      comment.isLikedByUser =
+        user.idsOfCommentLikedByUser.indexOf(comment.commentId) >= 0
+          ? true
+          : false;
     });
-    reComments.map((item) => {
-      item.isCreatedByUser = item.userId === userId ? true : false;
+
+    reComments.map((reComment) => {
+      reComment.isCreatedByUser =
+        user.idsOfCommentsCreatedByUser.indexOf(reComment.commentId) >= 0
+          ? true
+          : false;
+      reComment.isLikedByUser =
+        user.idsOfCommentLikedByUser.indexOf(reComment.commentId) >= 0
+          ? true
+          : false;
     });
 
     comments.map((comment) => {
@@ -195,6 +221,7 @@ export class CommunityService {
         return reComment['groupOrder'] === comment['groupOrder'];
       }));
     });
+
     return comments;
   }
 


### PR DESCRIPTION
유저가 추천한 댓글인지 여부를 불린으로 넣어줌.
그리고 댓글을 조회하는 쿼리와 대댓글을 조회하는 쿼리를 각각 나눠서 썼었는데
그것을 하나의 함수로 통합하는 리펙토링을 진행함. 코드량이 줄었음.
다만, 조회한 댓글과 대댓글을 서비스로직에서 map 메소드를 활용해 위 정보를 넣고
구조화하는 코드가 있는데 이 코드를 서비스 로직에서 분리해서 함수화하는 리펙토링을
추가적으로 진행해야 함