### PR TITLE
refactor : refresh guard 수정 및 로컬 https 서버 설정

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -25,6 +25,7 @@ import {
 import { GithubCodeDto, SignUpWithUserNameDto } from './dto/auth.dto';
 import {
   ApiBadRequestResponse,
+  ApiCookieAuth,
   ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
@@ -124,6 +125,7 @@ export class AuthController {
    */
   @UseGuards(JwtRefreshGuard)
   @Get('/sign-out')
+  @ApiCookieAuth()
   @ApiOperation({
     summary: '로그아웃',
     description: '로그아웃 시 응답 쿠키에 빈 값을 넣어 반환합니다.',
@@ -150,6 +152,7 @@ export class AuthController {
    */
   @UseGuards(JwtRefreshGuard)
   @Get('/refresh')
+  @ApiCookieAuth()
   @ApiOperation({
     summary: '엑세스 토큰 재발급',
     description: '리프레시 토큰으로 엑세스 토큰을 재발급 받습니다.',

--- a/src/auth/guard/jwt-refresh.guard.ts
+++ b/src/auth/guard/jwt-refresh.guard.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 /**
@@ -6,10 +6,4 @@ import { AuthGuard } from '@nestjs/passport';
  * @description refresh token을 검증하고 user 객체(id, name)를 req객체에 주입하는 guard입니다.
  */
 @Injectable()
-export class JwtRefreshGuard extends AuthGuard('jwt-refresh-token') {
-  canActivate(context: ExecutionContext) {
-    const req = context.switchToHttp().getRequest();
-    console.log('JwtRefreshGuard: Request received', req.signedCookies);
-    return super.canActivate(context);
-  }
-}
+export class JwtRefreshGuard extends AuthGuard('jwt-refresh-token') {}

--- a/src/auth/guard/jwt-refresh.guard.ts
+++ b/src/auth/guard/jwt-refresh.guard.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 /**
@@ -6,4 +6,10 @@ import { AuthGuard } from '@nestjs/passport';
  * @description refresh token을 검증하고 user 객체(id, name)를 req객체에 주입하는 guard입니다.
  */
 @Injectable()
-export class JwtRefreshGuard extends AuthGuard('jwt-refresh-token') {}
+export class JwtRefreshGuard extends AuthGuard('jwt-refresh-token') {
+  canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest();
+    console.log('JwtRefreshGuard: Request received', req.signedCookies);
+    return super.canActivate(context);
+  }
+}

--- a/src/auth/strategy/jwt-refresh.strategy.ts
+++ b/src/auth/strategy/jwt-refresh.strategy.ts
@@ -1,9 +1,9 @@
-import { RankerProfileRepository } from './../../rank/rankerProfile.repository';
 import { jwtConstants } from './../constants';
 import { UserService } from './../../user/user.service';
 import { Strategy, ExtractJwt } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { Request } from 'express';
 
 @Injectable()
 export class JwtRefreshStrategy extends PassportStrategy(
@@ -17,12 +17,13 @@ export class JwtRefreshStrategy extends PassportStrategy(
           return request?.signedCookies?.Refresh;
         },
       ]),
+      ignoreExpiration: false,
       secretOrKey: jwtConstants.jwtRefreshSecret,
-      passReqToCallBack: true,
+      passReqToCallback: true,
     });
   }
 
-  async validate(req, payload: any) {
+  async validate(req: Request, payload: any) {
     const refreshToken = req.signedCookies?.Refresh;
 
     if (!refreshToken)
@@ -30,10 +31,11 @@ export class JwtRefreshStrategy extends PassportStrategy(
 
     const { userId } = payload;
 
-    const user = this.userService.getUserIfRefreshTokenMatches(
+    const user = await this.userService.getUserIfRefreshTokenMatches(
       refreshToken,
       userId,
     );
+
     return user;
   }
 }

--- a/src/auth/strategy/jwt.strategy.ts
+++ b/src/auth/strategy/jwt.strategy.ts
@@ -15,11 +15,11 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: jwtConstants.jwtSecret,
+      ignoreExpiration: false,
     });
   }
 
   async validate(payload: any): Promise<AuthorizedUser> {
-    console.log('payload: ', payload);
     const { userId, userName } = payload;
 
     const userNameInDb = await this.rankerProfileRepository.getUserNameByUserId(

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -17,10 +17,7 @@ import { RankerProfile } from './RankerProfile';
 import { Field } from './Field';
 import { Career } from './Career';
 import { BooleanTransformer } from '../utils/boolean-transformer';
-<<<<<<< HEAD
 import { Exclude } from 'class-transformer';
-=======
->>>>>>> upstream/feature/oauth
 
 @Index('field_id', ['fieldId'], {})
 @Unique(['githubId'])

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,9 +12,18 @@ import * as morgan from 'morgan';
 import { ValidationError } from 'class-validator';
 import { SwaggerSetup } from './utils/swagger';
 import * as cookieParser from 'cookie-parser';
+import { readFileSync } from 'fs';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const ssl = process.env.SSL === 'true' ? true : false;
+  let httpsOptions = null;
+  if (ssl) {
+    httpsOptions = {
+      key: readFileSync(process.env.SSL_KEY_PATH),
+      cert: readFileSync(process.env.SSL_CERT_PATH),
+    };
+  }
+  const app = await NestFactory.create(AppModule, { httpsOptions });
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import * as morgan from 'morgan';
 import { ValidationError } from 'class-validator';
 import { SwaggerSetup } from './utils/swagger';
 import * as cookieParser from 'cookie-parser';
-import { readFileSync } from 'fs';
+import { readFileSync, readdir } from 'fs';
 
 async function bootstrap() {
   const ssl = process.env.SSL === 'true' ? true : false;
@@ -21,6 +21,7 @@ async function bootstrap() {
     httpsOptions = {
       key: readFileSync(process.env.SSL_KEY_PATH),
       cert: readFileSync(process.env.SSL_CERT_PATH),
+      ca: readFileSync(process.env.SSL_CA_PATH),
     };
   }
   const app = await NestFactory.create(AppModule, { httpsOptions });

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import * as morgan from 'morgan';
 import { ValidationError } from 'class-validator';
 import { SwaggerSetup } from './utils/swagger';
 import * as cookieParser from 'cookie-parser';
-import { readFileSync, readdir } from 'fs';
+import { readFileSync } from 'fs';
 
 async function bootstrap() {
   const ssl = process.env.SSL === 'true' ? true : false;

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from './../auth/guard/jwt-auth.guard';
 import {
   Body,
@@ -20,6 +20,7 @@ export class UserController {
 
   @UseGuards(JwtAuthGuard)
   @Get()
+  @ApiBearerAuth()
   @HttpCode(HttpStatus.OK)
   async getMyPage(@Req() req) {
     const userId = req.user.id;
@@ -28,6 +29,7 @@ export class UserController {
 
   @UseGuards(JwtAuthGuard)
   @Patch()
+  @ApiBearerAuth()
   @HttpCode(HttpStatus.CREATED)
   async updateMyPage(@Body() body: UpdateMyPageDto, @Req() req) {
     const userId = req.user.id;

--- a/src/utils/swagger.ts
+++ b/src/utils/swagger.ts
@@ -34,15 +34,26 @@ export class SwaggerSetup {
       .addTag('Ranks')
       .addTag('User')
       //JWT 토큰 설정
-      .addOAuth2(
+      .addBearerAuth(
         {
-          type: 'oauth2',
-          scheme: 'Bearer',
+          // type: 'oauth2',
+          // scheme: 'Bearer',
+          type: 'http',
+          scheme: 'bearer',
           name: 'Authorization',
           in: 'header',
+          bearerFormat: 'JWT',
+
+          // flows: {
+          //   authorizationCode: {
+          //     scopes: { write: '', read: '' },
+          //     authorizationUrl: `https://github.com/login/oauth/authorize?client_id=${process.env.AUTH_CLIENT_ID}`,
+          //   },
+          // },
         },
         'accessToken',
       )
+      .addCookieAuth('Refresh')
       .build();
 
     const swaggerOptions: SwaggerDocumentOptions = {


### PR DESCRIPTION
### 작업 내용
- refresh guard 오타 수정 : passReqToCallBack -> passReqToCallback
-> 이 오타 때문에 refreshGuard에서 계속 403 에러를 뱉어냄.
- 로컬 서버를 https 서버로 구동할 수 있도록 설정(mkcert) : [참고자료](https://growth-msleeffice.tistory.com/129) 
- swagger에서 front가 테스트 할 수 있는 환경 만들기 진행 중 : 가령 로그인 했을 때, token과 refresh 유지되게
