### PR TITLE
refactor : cookie domain 제거, samesite lax 설정, ERR_HTTP_HEADERS_SENT 에러 해결

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,4 @@ Dockerfile
 scripts
 dist
 *.pem
+.lh

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 *.pem
+
+.lh
+.vscode

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -219,9 +219,6 @@ describe('AuthController', () => {
       expect(mockRes.cookie).toHaveBeenCalledWith('Refresh', null, {
         expires: new Date(0),
       });
-      expect(mockRes.json).toHaveBeenCalledWith({
-        message: 'LOG_OUT_COMPLETED',
-      });
     });
   });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,14 +3,12 @@ import { RankService } from './../rank/rank.service';
 import { UserService } from './../user/user.service';
 import { RankerProfileRepository } from '../rank/rankerProfile.repository';
 import { AuthRepository } from './auth.repository';
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { GithubCodeDto, SignUpWithUserNameDto } from './dto/auth.dto';
 import { JwtService } from '@nestjs/jwt';
 import * as dotenv from 'dotenv';
 import { jwtConstants, cookieConstants } from './constants';
-import { AxiosRequestConfig } from 'axios';
 import { HttpService } from '@nestjs/axios';
-import { lastValueFrom, map } from 'rxjs';
 dotenv.config();
 
 @Injectable()
@@ -108,7 +106,7 @@ export class AuthService {
 
   async isRefreshTokenExpirationDateHalfPast(
     refreshToken: string,
-  ): Promise<Boolean> {
+  ): Promise<boolean> {
     const payload = await this.jwtService.verify(refreshToken, {
       secret: jwtConstants.jwtRefreshSecret,
     });

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -9,12 +9,12 @@ export const jwtConstants = {
 };
 
 export const cookieConstants = {
-  domain:
-    process.env.COOKIE_DOMAIN || process.env.COOKIE_DOMAIN_DEV || 'localhost',
+  // domain:
+  //   process.env.COOKIE_DOMAIN || process.env.COOKIE_DOMAIN_DEV || 'localhost',
   path: '/',
   httpOnly: true,
   maxAge: Number(jwtConstants.jwtRefreshExpiresIn) * 1000,
-  sameSite: 'none' as const,
+  // sameSite: 'none' as const,
   secure: true,
   signed: true,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { SwaggerSetup } from './utils/swagger';
 import * as cookieParser from 'cookie-parser';
 import { readFileSync } from 'fs';
 import * as basicAuth from 'express-basic-auth';
+import { NestExpressApplication } from '@nestjs/platform-express';
 
 async function bootstrap() {
   const ssl = process.env.SSL === 'true' ? true : false;
@@ -25,7 +26,9 @@ async function bootstrap() {
       ca: readFileSync(process.env.SSL_CA_PATH),
     };
   }
-  const app = await NestFactory.create(AppModule, { httpsOptions });
+  const app: NestExpressApplication = await NestFactory.create(AppModule, {
+    httpsOptions,
+  });
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
   app.useGlobalPipes(
     new ValidationPipe({
@@ -42,6 +45,7 @@ async function bootstrap() {
     }),
   );
 
+  app.set('trust proxy', true);
   app.useGlobalFilters(new AllExceptionsFilter());
   app.use(morgan('dev'));
   app.enableCors({

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { ApiBasicAuth, ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from './../auth/guard/jwt-auth.guard';
 import {
   Body,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -147,7 +147,7 @@ export class UserService {
   async getUserIfRefreshTokenMatches(refreshToken: string, id: number) {
     const user = await this.getById(id);
 
-    const isRefreshTokenMatching: Boolean = await this.verifyRefreshToken(
+    const isRefreshTokenMatching: boolean = await this.verifyRefreshToken(
       user.hashedRefreshToken,
       refreshToken,
     );


### PR DESCRIPTION
- cookie domain 옵션 제거, samesite 옵션 none에서 lax로 변경
-> cloudfront가 proxy 서버처럼 작동해서 도메인이 다를 때를 가정한 cookie 옵션을 없애야 cookie가 브라우저에 저장되는 것이 확인되었습니다. 이것도 명확한 이유는 잘 모르겠습니다.

- ERR_HTTP_HEADERS_SENT 에러 해결 : Cannot set headers after they are sent to the client
-> 보통 서버에서 하나의 응답에 복수 응답할 경우 발생하는 에러인데, 코드를 확인했을 때 응답은 1회만 이루어집니다. 그런데도 관련 오류가 계속 발생하여 공식문서를 확인해보니 res 후에 return을 하는 것을 보았고, 적용해보니 에러가 발생하지 않았습니다. 이것이 왜 문제 해결 방법인지에 대해서는 명확히 파악하지 못했습니다.
<img width="891" alt="error" src="https://user-images.githubusercontent.com/109528794/233023233-eaf99074-5413-4b56-a6c7-b2d19f64da0e.png">
